### PR TITLE
Firebase - Remote Config

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import { LogBox } from 'react-native';
 import Navigation from 'navigation';
 
 import useGetFavoriteCountryFromAsyncStorage from 'hooks/use-get-favorite-country-from-async-storage';
+import useFirebase from 'hooks/use-firebase';
 
 import GraphQLContext from 'context/graphql';
 
@@ -14,6 +15,7 @@ LogBox.ignoreLogs(['ViewPropTypes will be removed']);
 
 const App = (): JSX.Element => {
   useGetFavoriteCountryFromAsyncStorage();
+  useFirebase();
   return (
     <GraphQLContext.Provider>
       <Navigation />

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,6 +12,11 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.1)
   - Firebase/CoreOnly (8.15.0):
     - FirebaseCore (= 8.15.0)
+  - Firebase/RemoteConfig (8.15.0):
+    - Firebase/CoreOnly
+    - FirebaseRemoteConfig (~> 8.15.0)
+  - FirebaseABTesting (8.15.0):
+    - FirebaseCore (~> 8.0)
   - FirebaseCore (8.15.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
@@ -21,6 +26,17 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
+  - FirebaseInstallations (8.15.0):
+    - FirebaseCore (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/UserDefaults (~> 7.7)
+    - PromisesObjC (< 3.0, >= 1.2)
+  - FirebaseRemoteConfig (8.15.0):
+    - FirebaseABTesting (~> 8.0)
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -92,6 +108,9 @@ PODS:
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
+  - GoogleUtilities/UserDefaults (7.7.0):
+    - GoogleUtilities/Logger
   - libevent (2.1.12)
   - libwebp (1.2.1):
     - libwebp/demux (= 1.2.1)
@@ -400,6 +419,10 @@ PODS:
   - RNFBApp (14.11.0):
     - Firebase/CoreOnly (= 8.15.0)
     - React-Core
+  - RNFBRemoteConfig (14.11.0):
+    - Firebase/RemoteConfig (= 8.15.0)
+    - React-Core
+    - RNFBApp
   - RNGestureHandler (2.4.0):
     - React-Core
   - RNScreens (3.13.1):
@@ -477,6 +500,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - RNFastImage (from `../node_modules/react-native-fast-image`)
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
+  - "RNFBRemoteConfig (from `../node_modules/@react-native-firebase/remote-config`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -485,8 +509,11 @@ SPEC REPOS:
   trunk:
     - CocoaAsyncSocket
     - Firebase
+    - FirebaseABTesting
     - FirebaseCore
     - FirebaseCoreDiagnostics
+    - FirebaseInstallations
+    - FirebaseRemoteConfig
     - Flipper
     - Flipper-Boost-iOSX
     - Flipper-DoubleConversion
@@ -582,6 +609,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-fast-image"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
+  RNFBRemoteConfig:
+    :path: "../node_modules/@react-native-firebase/remote-config"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNScreens:
@@ -596,8 +625,11 @@ SPEC CHECKSUMS:
   FBLazyVector: 2c76493a346ef8cacf1f442926a39f805fffec1f
   FBReactNativeSpec: 371350f24afa87b6aba606972ec959dcd4a95c9a
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
+  FirebaseABTesting: 10cbce8db9985ae2e3847ea44e9947dd18f94e10
   FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
   FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
+  FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
+  FirebaseRemoteConfig: 2d6e2cfdb49af79535c8af8a80a4a5009038ec2b
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 3d3d04a078d4f3a1b6c6916587f159dc11f232c4
@@ -647,6 +679,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7
   RNFBApp: b1b5a80a676a07dea17e778bda7c1e8b69b2f5ec
+  RNFBRemoteConfig: 29ac04a2c3e7513c9ed4a5dac70d8feae603067a
   RNGestureHandler: 50e6ffee79932d14ea747d4ea4cc99aac0f24e86
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  coveragePathIgnorePatterns: ['/node_modules/'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '\\.svg': '<rootDir>/__mocks__/svgMock.js',
+    '^[@./a-zA-Z0-9$_-]+\\.(png|jpg|wav|mp4)$':
+      '<rootDir>/node_modules/react-native/jest/assetFileTransformer.js',
+    'assets/icons/(.*)': '<rootDir>/jest/svgMock.ts',
+  },
+  modulePaths: ['<rootDir>/src/'],
+  preset: 'react-native',
+  setupFiles: [
+    './node_modules/react-native-gesture-handler/jestSetup.js',
+    './jest/common-mocks.js',
+  ],
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/', '__generated__'],
+  transform: {
+    '^.+\\.(ts|tsx|js|jsx)$': 'babel-jest',
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native-community|@react-native.*|react-native.*|@?react-navigation.*)/)',
+  ],
+};

--- a/jest/common-mocks.js
+++ b/jest/common-mocks.js
@@ -1,0 +1,24 @@
+import mockAsyncStorage from '@react-native-community/async-storage/jest/async-storage-mock';
+
+jest.useFakeTimers();
+
+jest.mock('@react-native-community/async-storage', () => mockAsyncStorage);
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+jest.mock('react-native-gesture-handler', () => {
+  // eslint-disable-next-line global-require
+  const View = require('react-native/Libraries/Components/View/View');
+  return {
+    GestureHandlerRootView: View,
+    PanGestureHandler: View,
+  };
+});
+
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
+
+jest.mock('@react-native-firebase/remote-config', () => {
+  return {
+    default: jest.fn(),
+    remoteConfig: jest.fn(),
+  };
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@graphql-codegen/typescript-react-query": "^3.5.12",
     "@react-native-community/async-storage": "^1.12.1",
     "@react-native-firebase/app": "^14.11.0",
+    "@react-native-firebase/remote-config": "^14.11.0",
     "@react-navigation/bottom-tabs": "^6.3.1",
     "@react-navigation/core": "^6.2.1",
     "@react-navigation/native": "^6.0.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "graphql:gen:ts": "graphql-codegen --config ./src/state/codegen.yml",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "install-gems": "bundle install",
+    "install-ios": "cd ios && bundle exec pod install"
   },
   "dependencies": {
     "@apollo/client": "^3.5.10",

--- a/src/components/CountryList/index.tsx
+++ b/src/components/CountryList/index.tsx
@@ -3,7 +3,7 @@ import { View, FlatList, SafeAreaView } from 'react-native';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 
 import CountryTile from 'components/CountryTile';
-import type { CountryTileProps } from 'components/CountryTile';
+import type { CountryTileProps } from 'components/CountryTile/types';
 
 import styles, { Constants as StyleConstants } from './styles';
 

--- a/src/components/CountryTile/index.tsx
+++ b/src/components/CountryTile/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type { GetCountries } from 'state/remote/__generated__/default';
+import type { CountryTileProps } from './types';
 
 import {
   StyledTouchableOpacity,
@@ -12,18 +12,13 @@ import {
   StyledEmojiText,
 } from './styled-components';
 
-type Country = GetCountries.Node;
-
-export interface CountryTileProps extends Country {
-  onPress: (id: number) => void;
-}
-
 const CountryTile = ({
   id,
   name,
   capital,
   emoji,
   onPress,
+  highlight = false,
 }: CountryTileProps): JSX.Element => {
   const handleOnPress = React.useCallback(
     (): void => onPress(id),
@@ -31,11 +26,11 @@ const CountryTile = ({
   );
 
   return (
-    <StyledTouchableOpacity onPress={handleOnPress}>
+    <StyledTouchableOpacity onPress={handleOnPress} highlight={highlight}>
       <StyledLeftContentContainerView>
         <StyledNameText>{name}</StyledNameText>
         <StyledCapitalContainerView>
-          <StyledCapitalText>{capital}</StyledCapitalText>
+          <StyledCapitalText highlight={highlight}>{capital}</StyledCapitalText>
         </StyledCapitalContainerView>
       </StyledLeftContentContainerView>
       <StyledEmojiContainerView>

--- a/src/components/CountryTile/styled-components.ts
+++ b/src/components/CountryTile/styled-components.ts
@@ -4,8 +4,13 @@ import styled from 'styled-components/native';
 import Colors from 'styles/colors';
 import Fonts from 'styles/fonts';
 
-export const StyledTouchableOpacity = styled.TouchableOpacity`
-  background-color: ${() => Colors.platinum};
+import type { CountryTileProps } from './types';
+
+export const StyledTouchableOpacity = styled.TouchableOpacity<
+  Pick<CountryTileProps, 'highlight'>
+>`
+  background-color: ${(props) =>
+    props.highlight ? Colors.dartmouthGreen : Colors.platinum};
   border-radius: 10px;
   flex-direction: row;
   padding-top: 16px;
@@ -28,8 +33,10 @@ export const StyledCapitalContainerView = styled.View`
   padding-top: 2px;
 `;
 
-export const StyledCapitalText = styled.Text`
-  color: ${() => Colors.graniteGray};
+export const StyledCapitalText = styled.Text<
+  Pick<CountryTileProps, 'highlight'>
+>`
+  color: ${(props) => (props.highlight ? Colors.platinum : Colors.graniteGray)};
   font-family: ${() => Fonts.NunitoSansBold};
   font-size: 14px;
 `;

--- a/src/components/CountryTile/types.ts
+++ b/src/components/CountryTile/types.ts
@@ -1,0 +1,8 @@
+import type { GetCountries } from 'state/remote/__generated__/default';
+
+type Country = GetCountries.Node;
+
+export interface CountryTileProps extends Country {
+  onPress: (id: number) => void;
+  highlight?: boolean;
+}

--- a/src/hooks/use-firebase.ts
+++ b/src/hooks/use-firebase.ts
@@ -1,0 +1,33 @@
+import React from 'react';
+import remoteConfig from '@react-native-firebase/remote-config';
+
+import { updateFeatureFlags } from 'state/local/feature-flags';
+
+const useFirebase = (): void => {
+  const fetch = React.useCallback(async (): Promise<void> => {
+    try {
+      await remoteConfig().setConfigSettings({
+        minimumFetchIntervalMillis: 3000,
+      });
+      await remoteConfig().setDefaults({
+        enableFavoriteCountryHighlight: true,
+      });
+      const fetchedRemotely = remoteConfig().fetchAndActivate();
+      if (fetchedRemotely !== null) {
+        const enableFavoriteCountryHighlight = remoteConfig().getBoolean(
+          'enableFavoriteCountryHighlight',
+        );
+        updateFeatureFlags({ enableFavoriteCountryHighlight });
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(`[Firebase] Error when trying to get remote config: ${e}`);
+    }
+  }, []);
+
+  React.useEffect((): void => {
+    fetch();
+  }, [fetch]);
+};
+
+export default useFirebase;

--- a/src/hooks/use-firebase.ts
+++ b/src/hooks/use-firebase.ts
@@ -5,6 +5,8 @@ import { updateFeatureFlags } from 'state/local/feature-flags';
 
 const useFirebase = (): void => {
   const fetch = React.useCallback(async (): Promise<void> => {
+    if (process.env.JEST_WORKER_ID) return;
+
     try {
       await remoteConfig().setConfigSettings({
         minimumFetchIntervalMillis: 3000,

--- a/src/routes/Countries/index.tsx
+++ b/src/routes/Countries/index.tsx
@@ -13,7 +13,7 @@ import routes from 'routes';
 import type { StandaloneNavigationParams } from 'navigation/CountryNavigator/types';
 
 import CountryList from 'components/CountryList';
-import type { CountryTileProps } from 'components/CountryTile';
+import type { CountryTileProps } from 'components/CountryTile/types';
 import LoadingOrTapToRefresh from 'components/LoadingOrTapToRefresh';
 
 import {

--- a/src/routes/Countries/index.tsx
+++ b/src/routes/Countries/index.tsx
@@ -8,6 +8,9 @@ import { client } from 'state/graphql-config';
 
 import { useInfiniteGetCountriesQuery } from 'state/remote/__generated__/default';
 
+import useFeatureFlags from 'state/local/feature-flags/hooks/use-feature-flags';
+import useFavoriteCountry from 'state/local/favorite-country/hooks/use-favorite-country';
+
 import routes from 'routes';
 
 import type { StandaloneNavigationParams } from 'navigation/CountryNavigator/types';
@@ -37,6 +40,11 @@ const Countries = (): JSX.Element => {
       },
     );
 
+  const {
+    featureFlags: { enableFavoriteCountryHighlight },
+  } = useFeatureFlags();
+  const { favoriteCountry } = useFavoriteCountry();
+
   const { navigate } =
     useNavigation<NavigationProp<StandaloneNavigationParams>>();
 
@@ -50,11 +58,17 @@ const Countries = (): JSX.Element => {
     data?.pages.forEach((page) =>
       page.countries.edges.forEach((country) => {
         const onPress = () => handleOnPress(country.node.id);
-        countries.push({ ...country.node, onPress });
+        countries.push({
+          ...country.node,
+          highlight:
+            !!enableFavoriteCountryHighlight &&
+            favoriteCountry.id === country.node.id,
+          onPress,
+        });
       }),
     );
     return countries;
-  }, [data, handleOnPress]);
+  }, [data, handleOnPress, enableFavoriteCountryHighlight, favoriteCountry]);
 
   const [hasMomentumScrollBegin, setHasMomentumScrollBegin] =
     React.useState(false);

--- a/src/state/local/feature-flags/hooks/use-feature-flags.ts
+++ b/src/state/local/feature-flags/hooks/use-feature-flags.ts
@@ -1,0 +1,21 @@
+import { useReactiveVar } from '@apollo/client';
+
+import type { FeatureFlags } from 'state/local/feature-flags';
+import FeatureFlagsHandleFunctions, {
+  featureFlagsVar,
+} from 'state/local/feature-flags';
+
+interface FeatureFlagsHandler {
+  featureFlags: FeatureFlags;
+  updateFeatureFlags: (partialFeatureFlags: Partial<FeatureFlags>) => void;
+}
+
+const useFeatureFlags = (): FeatureFlagsHandler => {
+  const featureFlags = useReactiveVar(featureFlagsVar);
+  return {
+    ...FeatureFlagsHandleFunctions,
+    featureFlags,
+  };
+};
+
+export default useFeatureFlags;

--- a/src/state/local/feature-flags/index.tsx
+++ b/src/state/local/feature-flags/index.tsx
@@ -1,0 +1,22 @@
+import { makeVar } from '@apollo/client';
+
+export interface FeatureFlags {
+  enableFavoriteCountryHighlight: boolean | null;
+}
+
+const defaultFeatureFlags: FeatureFlags = {
+  enableFavoriteCountryHighlight: null,
+};
+
+export const featureFlagsVar = makeVar<FeatureFlags>(defaultFeatureFlags);
+
+export const updateFeatureFlags = (
+  partialFeatureFlags: Partial<FeatureFlags>,
+): void => {
+  const featureFlags = featureFlagsVar();
+  featureFlagsVar({ ...featureFlags, ...partialFeatureFlags });
+};
+
+export default {
+  updateFeatureFlags,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,6 +2101,11 @@
     opencollective-postinstall "^2.0.1"
     superstruct "^0.6.2"
 
+"@react-native-firebase/remote-config@^14.11.0":
+  version "14.11.0"
+  resolved "https://registry.yarnpkg.com/@react-native-firebase/remote-config/-/remote-config-14.11.0.tgz#f3e0fabb2c1794fea466eba034df242b32d3cdd4"
+  integrity sha512-yZ9fu3ckZ55t3nrtDnZ5ju60dzMuu24+xhrFHMnYBfc2jeUekwB6R3qXt9rurguT89XHCUOXWUtHvzZf+T14hA==
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"


### PR DESCRIPTION
## Description

This patchset adds the "Firebase - Remote Config" functionality. The following changes were made in order to make it work properly in our application:

* add and configure/setup the `@react-native-firebase/remote-config` lib
  * the "setup/config" is being placed in a new hook called `useFirebase`
* a remote config was added in the Firebase console: `enableFavoriteCountryHighlight`
* in order to make it usable in the codebase, a new feature was made in the `CountryTile` component to allow the tile to be "highlighted"
* other changes in this patchset not directly related to this feature:
  * add two new scripts in the `package.json` file: `install-gems` and `install-ios`
  * add changes to make `yarn test` passes the tests

## How to test it?

* change the `enableFavoriteCountryHighlight` value in the Firebase config -> rebuild the app and check how the app behaves with these changes

## Visual references

* `enableFavoriteCountryHighlight` is `true`

<img src="https://user-images.githubusercontent.com/16086636/172062883-3332fb95-7c27-4b53-81a8-dfa5ebdd8c1a.png" width="450" />


* `enableFavoriteCountryHighlight` is `false`
<img src="https://user-images.githubusercontent.com/16086636/172062902-9a9cf539-96b9-486d-a767-2155feeb7542.png" width="450" />


